### PR TITLE
(vitineth/permissions): signup delete permission upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^14.0.14",
     "@types/passport": "^1.0.4",
     "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.50",
+    "@uems/uemscommlib": "0.1.0-beta.51",
     "ajv": "^6.12.3",
     "amqplib": "^0.7.1",
     "body-parser": "^1.19.0",

--- a/src/attachments/attachments/EntStateGatewayInterface.ts
+++ b/src/attachments/attachments/EntStateGatewayInterface.ts
@@ -129,19 +129,9 @@ export class EntStateGatewayInterface implements GatewayAttachmentInterface {
                 msg_intention: 'READ',
                 status: 0,
                 userID: req.uemsUser.userID,
+                id: req.params.id,
             };
 
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            outgoingMessage.id = req.params.id;
             await send(
                 ROUTING_KEY.ent.read,
                 outgoingMessage,
@@ -189,16 +179,6 @@ export class EntStateGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteEntStateHandler(send: GatewayMk2.SendRequestFunction, resolver: EntityResolver, handler: GatewayMessageHandler) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -208,35 +188,11 @@ export class EntStateGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            //
-            // const outgoingMessage: any = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.ent.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateEntStateHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const validate = MessageUtilities.verifyBody(
                 req,
                 res,

--- a/src/attachments/attachments/EntStateGatewayInterface.ts
+++ b/src/attachments/attachments/EntStateGatewayInterface.ts
@@ -17,6 +17,7 @@ import CreateEntStateMessage = EntStateMessage.CreateEntStateMessage;
 import UpdateEntStateMessage = EntStateMessage.UpdateEntStateMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
+import sendZodError = MessageUtilities.sendZodError;
 
 export class EntStateGatewayInterface implements GatewayAttachmentInterface {
     private readonly COLOR_REGEX = /^#?([0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?)$/;
@@ -153,7 +154,7 @@ export class EntStateGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!bodyValidate.success) {
-                // TODO: error handling?
+                sendZodError(res, bodyValidate.error);
                 return;
             }
 
@@ -206,7 +207,7 @@ export class EntStateGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
-                // TODO: error handling
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/EquipmentGatewayInterface.ts
+++ b/src/attachments/attachments/EquipmentGatewayInterface.ts
@@ -16,6 +16,7 @@ import CreateEquipmentMessage = EquipmentMessage.CreateEquipmentMessage;
 import UpdateEquipmentMessage = EquipmentMessage.UpdateEquipmentMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
+import CoercingValidator = MessageUtilities.CoercingValidator;
 
 export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
 
@@ -80,24 +81,26 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
                 userID: req.uemsUser.userID,
             };
 
+            const types: CoercingValidator = {
+                amount: { primitive: 'number' },
+                assetID: { primitive: 'string' },
+                category: { primitive: 'string' },
+                date: { primitive: 'number' },
+                id: { primitive: 'string' },
+                locationID: { primitive: 'string' },
+                locationSpecifier: { primitive: 'string' },
+                managerID: { primitive: 'string' },
+                manufacturer: { primitive: 'string' },
+                miscIdentifier: { primitive: 'string' },
+                model: { primitive: 'string' },
+                name: { primitive: 'string' },
+            };
+
             const validate = MessageUtilities.coerceAndVerifyQuery(
                 req,
                 res,
                 [],
-                {
-                    id: { primitive: 'string' },
-                    assetID: { primitive: 'string' },
-                    name: { primitive: 'string' },
-                    manufacturer: { primitive: 'string' },
-                    model: { primitive: 'string' },
-                    miscIdentifier: { primitive: 'string' },
-                    amount: { primitive: 'number' },
-                    locationID: { primitive: 'string' },
-                    locationSpecifier: { primitive: 'string' },
-                    managerID: { primitive: 'string' },
-                    date: { primitive: 'number' },
-                    category: { primitive: 'string' },
-                },
+                types,
             );
 
             if (!validate) {
@@ -105,20 +108,7 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
             }
 
             const parameters = req.query;
-            const validProperties: string[] = [
-                'id',
-                'assetID',
-                'name',
-                'manufacturer',
-                'model',
-                'miscIdentifier',
-                'amount',
-                'locationID',
-                'locationSpecifier',
-                'managerID',
-                'date',
-                'category',
-            ];
+            const validProperties: string[] = Object.keys(types);
 
             validProperties.forEach((key) => {
                 if (MessageUtilities.has(parameters, key)) {

--- a/src/attachments/attachments/EquipmentGatewayInterface.ts
+++ b/src/attachments/attachments/EquipmentGatewayInterface.ts
@@ -136,19 +136,9 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
                 msg_intention: 'READ',
                 status: 0,
                 userID: req.uemsUser.userID,
+                id: req.params.id,
             };
 
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            outgoingMessage.id = req.params.id;
             await send(
                 ROUTING_KEY.equipment.read,
                 outgoingMessage,
@@ -224,17 +214,6 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteEquipmentHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -244,37 +223,11 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            //
-            // const outgoingMessage: DeleteEquipmentMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.equipment.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateEquipmentHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            // ID is carried in the parameter not the body so have to do it this way
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoing: UpdateEquipmentMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'UPDATE',

--- a/src/attachments/attachments/EquipmentGatewayInterface.ts
+++ b/src/attachments/attachments/EquipmentGatewayInterface.ts
@@ -18,6 +18,7 @@ import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
 import CoercingValidator = MessageUtilities.CoercingValidator;
 import * as zod from 'zod';
+import sendZodError = MessageUtilities.sendZodError;
 
 export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
 
@@ -172,7 +173,7 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
-                // TODO: error responses
+                sendZodError(res, validate.error);
                 return;
             }
             const body = validate.data;
@@ -244,7 +245,7 @@ export class EquipmentGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
-                // TODO: error response
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/EventGatewayAttachment.ts
+++ b/src/attachments/attachments/EventGatewayAttachment.ts
@@ -148,6 +148,7 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
                 localOnly,
             };
 
+            // TODO: migrate to zod
             const validate = MessageUtilities.verifyBody(
                 req,
                 res,
@@ -157,7 +158,9 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
                     start: (x) => typeof (x) === 'number' || typeof (x) === 'undefined',
                     end: (x) => typeof (x) === 'number' || typeof (x) === 'undefined',
                     attendance: (x) => typeof (x) === 'number' || typeof (x) === 'undefined',
+                    // TODO: typing of array elements?
                     addVenues: (x) => Array.isArray(x) || typeof (x) === 'undefined',
+                    // TODO: typing of array elements
                     removeVenues: (x) => Array.isArray(x) || typeof (x) === 'undefined',
                     ents: (x) => typeof (x) === 'string' || typeof (x) === 'undefined',
                     state: (x) => typeof (x) === 'string' || typeof (x) === 'undefined',
@@ -234,20 +237,20 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             res,
             [],
             {
-                name: { primitive: 'string' },
-                start: { primitive: 'number' },
-                end: { primitive: 'number' },
                 attendance: { primitive: 'number' },
-                venueIDs: { primitive: 'array' },
-                venueCriteria: { primitive: 'string' },
-                entsID: { primitive: 'string' },
-                stateID: { primitive: 'string' },
-                startafter: { primitive: 'number' },
-                startbefore: { primitive: 'number' },
-                endafter: { primitive: 'number' },
-                endbefore: { primitive: 'number' },
                 attendanceGreater: { primitive: 'number' },
                 attendanceLess: { primitive: 'number' },
+                end: { primitive: 'number' },
+                endafter: { primitive: 'number' },
+                endbefore: { primitive: 'number' },
+                entsID: { primitive: 'string' },
+                name: { primitive: 'string' },
+                start: { primitive: 'number' },
+                startafter: { primitive: 'number' },
+                startbefore: { primitive: 'number' },
+                stateID: { primitive: 'string' },
+                venueCriteria: { primitive: 'string' },
+                venueIDs: { primitive: 'array' },
             },
         );
 
@@ -279,6 +282,7 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             msg.attendance = parseInt(req.query.attendance.toString(), 10);
         }
 
+        // TODO: what to do if its not valid, verify it above?
         if (req.query.venueIDs !== undefined && typeof (req.query.venueIDs) === 'string') {
             if (req.query.venueCriteria !== undefined) {
                 if (req.query.venueCriteria === 'all') {

--- a/src/attachments/attachments/EventGatewayAttachment.ts
+++ b/src/attachments/attachments/EventGatewayAttachment.ts
@@ -112,20 +112,6 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const msg: DeleteEventMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     status: 0,
-            //     msg_intention: 'DELETE',
-            //     id: eventId,
-            //     userID: req.uemsUser.userID,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.event.delete,
-            //     msg,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
@@ -351,20 +337,9 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
                 msg_intention: 'READ',
                 status: 0,
                 userID: req.uemsUser.userID,
+                id: req.params.id,
                 localOnly,
             };
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            outgoingMessage.id = req.params.id;
 
             await send(
                 ROUTING_KEY.event.read,
@@ -451,20 +426,9 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             status: 0,
             msg_intention: 'READ',
             userID: req.uemsUser.userID,
+            stateID: req.params.id,
             localOnly,
         };
-
-        if (!MessageUtilities.has(req.params, 'id')) {
-            res
-                .status(constants.HTTP_STATUS_BAD_REQUEST)
-                .json(MessageUtilities.wrapInFailure({
-                    message: 'missing parameter id',
-                    code: 'BAD_REQUEST_MISSING_PARAM',
-                }));
-            return;
-        }
-
-        msg.stateID = req.params.id;
 
         await send(
             ROUTING_KEY.event.read,
@@ -490,20 +454,9 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             status: 0,
             msg_intention: 'READ',
             userID: req.uemsUser.userID,
+            anyVenues: [req.params.id],
             localOnly,
         };
-
-        if (!MessageUtilities.has(req.params, 'id')) {
-            res
-                .status(constants.HTTP_STATUS_BAD_REQUEST)
-                .json(MessageUtilities.wrapInFailure({
-                    message: 'missing parameter id',
-                    code: 'BAD_REQUEST_MISSING_PARAM',
-                }));
-            return;
-        }
-
-        msg.anyVenues = [req.params.id];
 
         await send(
             ROUTING_KEY.event.read,
@@ -530,20 +483,9 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             msg_intention: 'READ',
             userID: req.uemsUser.userID,
             localAssetOnly: localOnly,
+            assetType: 'event',
+            assetID: req.params.id,
         };
-
-        if (!MessageUtilities.has(req.params, 'id')) {
-            res
-                .status(constants.HTTP_STATUS_BAD_REQUEST)
-                .json(MessageUtilities.wrapInFailure({
-                    message: 'missing parameter id',
-                    code: 'BAD_REQUEST_MISSING_PARAM',
-                }));
-            return;
-        }
-
-        msg.assetType = 'event';
-        msg.assetID = req.params.id;
 
         await send(
             'events.comment.get',

--- a/src/attachments/attachments/EventGatewayAttachment.ts
+++ b/src/attachments/attachments/EventGatewayAttachment.ts
@@ -467,6 +467,7 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
                 .safeParse(request.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/EventGatewayAttachment.ts
+++ b/src/attachments/attachments/EventGatewayAttachment.ts
@@ -157,7 +157,7 @@ export class EventGatewayAttachment implements GatewayAttachmentInterface {
             const body = validate.data;
             for (const [k, v] of Object.entries(body)) {
                 // @ts-ignore
-                outgoing[k] = v;
+                msg[k] = v;
             }
 
             await send(

--- a/src/attachments/attachments/FileGatewayInterface.ts
+++ b/src/attachments/attachments/FileGatewayInterface.ts
@@ -211,6 +211,7 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 
@@ -380,6 +381,7 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/FileGatewayInterface.ts
+++ b/src/attachments/attachments/FileGatewayInterface.ts
@@ -120,12 +120,12 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 res,
                 [],
                 {
+                    date: { primitive: 'number' },
+                    filename: { primitive: 'string' },
                     id: { primitive: 'string' },
                     name: { primitive: 'string' },
-                    filename: { primitive: 'string' },
                     size: { primitive: 'number' },
                     type: { primitive: 'string' },
-                    date: { primitive: 'number' },
                     userid: { primitive: 'string' },
                 },
             );
@@ -316,6 +316,7 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 id: req.params.id,
             };
 
+            // TODO: no type validation here
             const parameters = req.body;
             const validProperties: (keyof FileReadSchema)[] = [
                 'name',
@@ -463,6 +464,7 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
         };
     }
 
+    // TODO: document on stoplight
     private deleteFileFromEventHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
             if (!MessageUtilities.has(req.params, 'eventID')) {

--- a/src/attachments/attachments/FileGatewayInterface.ts
+++ b/src/attachments/attachments/FileGatewayInterface.ts
@@ -177,20 +177,10 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 msg_intention: 'READ',
                 status: 0,
                 userID: req.uemsUser.userID,
+                id: req.params.id,
                 localOnly,
             };
 
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            outgoingMessage.id = req.params.id;
             await send(
                 ROUTING_KEY.file.read,
                 outgoingMessage,
@@ -260,16 +250,6 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteFileHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this._resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -279,35 +259,11 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const outgoingMessage: DeleteFileMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.file.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateFileHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoing: UpdateFileMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'UPDATE',
@@ -341,15 +297,6 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
 
     private getEventsByFileHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
             let localOnly = true;
             if (req.kauth && req.kauth.grant && req.kauth.grant.access_token) {
                 // req.kauth.grant.kauth
@@ -379,15 +326,6 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
 
     private getFilesByEventsHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
             let localOnly = true;
             if (req.kauth && req.kauth.grant && req.kauth.grant.access_token) {
                 // req.kauth.grant.kauth
@@ -417,15 +355,6 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
 
     private postFileToEventHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
             let localOnly = true;
             if (req.kauth && req.kauth.grant && req.kauth.grant.access_token) {
                 // req.kauth.grant.kauth
@@ -467,25 +396,6 @@ export class FileGatewayInterface implements GatewayAttachmentInterface {
     // TODO: document on stoplight
     private deleteFileFromEventHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-            if (!MessageUtilities.has(req.params, 'fileID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter fileID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoingMessage: UnbindFilesFromEventMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'DELETE',

--- a/src/attachments/attachments/SignupGatewayInterface.ts
+++ b/src/attachments/attachments/SignupGatewayInterface.ts
@@ -75,16 +75,6 @@ export class SignupGatewayInterface implements GatewayAttachmentInterface {
 
     private querySignupsHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoing: ReadSignupMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -143,26 +133,6 @@ export class SignupGatewayInterface implements GatewayAttachmentInterface {
 
     private getSignupHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoingMessage: ReadSignupMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -187,16 +157,6 @@ export class SignupGatewayInterface implements GatewayAttachmentInterface {
 
     private createSignupHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             // TODO: this is not verifying the right hting?
             const validate = MessageUtilities.verifyBody(
                 req,
@@ -253,26 +213,6 @@ export class SignupGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteSignupHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             let localOnly = true;
             if (req.kauth && req.kauth.grant && req.kauth.grant.access_token) {
                 // req.kauth.grant.kauth
@@ -288,45 +228,11 @@ export class SignupGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const outgoingMessage: DeleteSignupMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.signups.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateSignupHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'eventID')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter eventID',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             let localOnly = true;
             if (req.kauth && req.kauth.grant && req.kauth.grant.access_token) {
                 if (orProtect('admin')(req.kauth.grant.access_token)) {

--- a/src/attachments/attachments/StateGatewayInterface.ts
+++ b/src/attachments/attachments/StateGatewayInterface.ts
@@ -213,6 +213,7 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/StateGatewayInterface.ts
+++ b/src/attachments/attachments/StateGatewayInterface.ts
@@ -123,16 +123,6 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
 
     private getStateHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
             const outgoingMessage: ReadStateMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -188,16 +178,6 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteStateHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -207,35 +187,11 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const outgoingMessage: DeleteStateMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.states.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateStateHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoing: UpdateStateMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'UPDATE',
@@ -272,8 +228,6 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
                     outgoing[key] = parameters[key];
                 }
             });
-
-            console.log('sending?');
 
             await send(
                 ROUTING_KEY.states.update,

--- a/src/attachments/attachments/StateGatewayInterface.ts
+++ b/src/attachments/attachments/StateGatewayInterface.ts
@@ -16,6 +16,8 @@ import CreateStateMessage = StateMessage.CreateStateMessage;
 import UpdateStateMessage = StateMessage.UpdateStateMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
+import * as zod from 'zod';
+import sendZodError = MessageUtilities.sendZodError;
 
 export class StateGatewayInterface implements GatewayAttachmentInterface {
 
@@ -142,29 +144,28 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
 
     private createStateHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            const validate = MessageUtilities.verifyBody(
-                req,
-                res,
-                ['name', 'icon', 'color'],
-                {
-                    name: (x) => typeof (x) === 'string',
-                    icon: (x) => typeof (x) === 'string',
-                    color: (x) => typeof (x) === 'string' && this.COLOR_REGEX.test(x),
-                },
-            );
+            const validate = zod.object({
+                name: zod.string(),
+                icon: zod.string(),
+                color: zod.string()
+                    .regex(this.COLOR_REGEX),
+            })
+                .safeParse(req.body);
 
-            if (!validate) {
+            if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
+            const body = req.body;
 
             const outgoingMessage: CreateStateMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'CREATE',
                 status: 0,
                 userID: req.uemsUser.userID,
-                color: req.body.color,
-                icon: req.body.icon,
-                name: req.body.name,
+                color: body.color,
+                icon: body.icon,
+                name: body.name,
             };
 
             await send(
@@ -200,18 +201,18 @@ export class StateGatewayInterface implements GatewayAttachmentInterface {
                 id: req.params.id,
             };
 
-            const validate = MessageUtilities.verifyBody(
-                req,
-                res,
-                [],
-                {
-                    name: (x) => typeof (x) === 'string',
-                    icon: (x) => typeof (x) === 'string',
-                    color: (x) => typeof (x) === 'string' && this.COLOR_REGEX.test(x),
-                },
-            );
+            const validate = zod.object({
+                name: zod.string()
+                    .optional(),
+                icon: zod.string()
+                    .optional(),
+                color: zod.string()
+                    .regex(this.COLOR_REGEX)
+                    .optional(),
+            })
+                .safeParse(req.body);
 
-            if (!validate) {
+            if (!validate.success) {
                 return;
             }
 

--- a/src/attachments/attachments/TopicGatewayInterface.ts
+++ b/src/attachments/attachments/TopicGatewayInterface.ts
@@ -89,7 +89,7 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
                     icon: { primitive: 'string' },
                     color: {
                         primitive: 'string',
-                        validator: this.COLOR_REGEX.test
+                        validator: (x) => this.COLOR_REGEX.test(x)
                     },
                     description: { primitive: 'string' },
                     id: { primitive: 'string' },

--- a/src/attachments/attachments/TopicGatewayInterface.ts
+++ b/src/attachments/attachments/TopicGatewayInterface.ts
@@ -17,6 +17,7 @@ import UpdateTopicMessage = TopicMessage.UpdateTopicMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
 import * as zod from 'zod';
+import sendZodError = MessageUtilities.sendZodError;
 
 export class TopicGatewayInterface implements GatewayAttachmentInterface {
 
@@ -154,6 +155,7 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 
@@ -209,6 +211,7 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(req.body);
 
             if (!validate.success) {
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/TopicGatewayInterface.ts
+++ b/src/attachments/attachments/TopicGatewayInterface.ts
@@ -122,16 +122,6 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
 
     private getTopicHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoingMessage: ReadTopicMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -188,16 +178,6 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteTopicHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -207,20 +187,6 @@ export class TopicGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const outgoingMessage: DeleteTopicMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.topic.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 

--- a/src/attachments/attachments/UserGatewayInterface.ts
+++ b/src/attachments/attachments/UserGatewayInterface.ts
@@ -69,6 +69,7 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
         ];
     }
 
+    // TODO: permission management on query
     private queryUsersHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
             const outgoing: ReadUserMessage = {
@@ -83,12 +84,12 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
                 res,
                 [],
                 {
+                    email: { primitive: 'string' },
                     id: { primitive: 'string' },
+                    includeEmail: { primitive: 'boolean' },
+                    includeHash: { primitive: 'boolean' },
                     name: { primitive: 'string' },
                     username: { primitive: 'string' },
-                    email: { primitive: 'string' },
-                    includeHash: { primitive: 'boolean' },
-                    includeEmail: { primitive: 'boolean' },
                 },
             );
 

--- a/src/attachments/attachments/UserGatewayInterface.ts
+++ b/src/attachments/attachments/UserGatewayInterface.ts
@@ -15,6 +15,7 @@ import CreateUserMessage = UserMessage.CreateUserMessage;
 import UpdateUserMessage = UserMessage.UpdateUserMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
+import * as zod from 'zod';
 
 export class UserGatewayInterface implements GatewayAttachmentInterface {
 
@@ -37,13 +38,13 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
                 handle: this.queryUsersHandler(send),
                 additionalValidator: validator,
             },
-            {
-                action: 'post',
-                path: '/user',
-                handle: this.createUserHandler(send),
-                additionalValidator: validator,
-                secure: ['admin'],
-            },
+            // {
+            //     action: 'post',
+            //     path: '/user',
+            //     handle: this.createUserHandler(send),
+            //     additionalValidator: validator,
+            //     secure: ['admin'],
+            // },
             {
                 action: 'delete',
                 path: '/user/:id',
@@ -141,47 +142,47 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
         };
     }
 
-    private createUserHandler(send: SendRequestFunction) {
-        return async (req: Request, res: Response) => {
-            const validate = MessageUtilities.verifyBody(
-                req,
-                res,
-                ['name', 'username', 'email', 'hash'],
-                {
-                    name: (x) => typeof (x) === 'string',
-                    username: (x) => typeof (x) === 'string',
-                    email: (x) => typeof (x) === 'string',
-                    hash: (x) => typeof (x) === 'string',
-                    profile: (x) => typeof (x) === 'string',
-                },
-            );
-
-            if (!validate) {
-                return;
-            }
-
-            const outgoingMessage: CreateUserMessage = {
-                msg_id: MessageUtilities.generateMessageIdentifier(),
-                msg_intention: 'CREATE',
-                id: req.body.username,
-                status: 0,
-                userID: req.uemsUser.userID,
-                name: req.body.name,
-                username: req.body.username,
-                email: req.body.email,
-                hash: req.body.hash,
-            };
-
-            if (req.body.profile) outgoingMessage.profile = req.body.profile;
-
-            await send(
-                ROUTING_KEY.user.create,
-                outgoingMessage,
-                res,
-                GenericHandlerFunctions.handleDefaultResponseFactory(),
-            );
-        };
-    }
+    // private createUserHandler(send: SendRequestFunction) {
+    //     return async (req: Request, res: Response) => {
+    //         const validate = MessageUtilities.verifyBody(
+    //             req,
+    //             res,
+    //             ['name', 'username', 'email', 'hash'],
+    //             {
+    //                 name: (x) => typeof (x) === 'string',
+    //                 username: (x) => typeof (x) === 'string',
+    //                 email: (x) => typeof (x) === 'string',
+    //                 hash: (x) => typeof (x) === 'string',
+    //                 profile: (x) => typeof (x) === 'string',
+    //             },
+    //         );
+    //
+    //         if (!validate) {
+    //             return;
+    //         }
+    //
+    //         const outgoingMessage: CreateUserMessage = {
+    //             msg_id: MessageUtilities.generateMessageIdentifier(),
+    //             msg_intention: 'CREATE',
+    //             id: req.body.username,
+    //             status: 0,
+    //             userID: req.uemsUser.userID,
+    //             name: req.body.name,
+    //             username: req.body.username,
+    //             email: req.body.email,
+    //             hash: req.body.hash,
+    //         };
+    //
+    //         if (req.body.profile) outgoingMessage.profile = req.body.profile;
+    //
+    //         await send(
+    //             ROUTING_KEY.user.create,
+    //             outgoingMessage,
+    //             res,
+    //             GenericHandlerFunctions.handleDefaultResponseFactory(),
+    //         );
+    //     };
+    // }
 
     private deleteUserHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
@@ -199,20 +200,21 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
 
     private updateUserHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            const validate = MessageUtilities.verifyBody(
-                req,
-                res,
-                [],
-                {
-                    name: (x) => typeof (x) === 'string',
-                    username: (x) => typeof (x) === 'string',
-                    email: (x) => typeof (x) === 'string',
-                    profile: (x) => typeof (x) === 'string',
-                    hash: (x) => typeof (x) === 'string',
-                },
-            );
+            const validate = zod.object({
+                name: zod.string()
+                    .optional(),
+                username: zod.string()
+                    .optional(),
+                email: zod.string()
+                    .optional(),
+                profile: zod.string()
+                    .optional(),
+                hash: zod.string()
+                    .optional(),
+            }).safeParse(req.body);
 
-            if (!validate) {
+            if (!validate.success) {
+                // TODO: error handling
                 return;
             }
 

--- a/src/attachments/attachments/UserGatewayInterface.ts
+++ b/src/attachments/attachments/UserGatewayInterface.ts
@@ -125,16 +125,6 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
 
     private getUserHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoingMessage: ReadUserMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -195,16 +185,6 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
 
     private deleteUserHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: req.params.id,
@@ -214,35 +194,11 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
                 res.status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                     .json(MessageUtilities.wrapInFailure(ErrorCodes.FAILED));
             }
-            // const outgoingMessage: DeleteUserMessage = {
-            //     msg_id: MessageUtilities.generateMessageIdentifier(),
-            //     msg_intention: 'DELETE',
-            //     status: 0,
-            //     userID: req.uemsUser.userID,
-            //     id: req.params.id,
-            // };
-            //
-            // await send(
-            //     ROUTING_KEY.user.delete,
-            //     outgoingMessage,
-            //     res,
-            //     GenericHandlerFunctions.handleReadSingleResponseFactory(),
-            // );
         };
     }
 
     private updateUserHandler(send: SendRequestFunction) {
         return async (req: Request, res: Response) => {
-            if (!MessageUtilities.has(req.params, 'id')) {
-                res
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const validate = MessageUtilities.verifyBody(
                 req,
                 res,

--- a/src/attachments/attachments/UserGatewayInterface.ts
+++ b/src/attachments/attachments/UserGatewayInterface.ts
@@ -16,6 +16,7 @@ import UpdateUserMessage = UserMessage.UpdateUserMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
 import * as zod from 'zod';
+import sendZodError = MessageUtilities.sendZodError;
 
 export class UserGatewayInterface implements GatewayAttachmentInterface {
 
@@ -214,7 +215,7 @@ export class UserGatewayInterface implements GatewayAttachmentInterface {
             }).safeParse(req.body);
 
             if (!validate.success) {
-                // TODO: error handling
+                sendZodError(res, validate.error);
                 return;
             }
 

--- a/src/attachments/attachments/VenueGatewayInterface.ts
+++ b/src/attachments/attachments/VenueGatewayInterface.ts
@@ -72,16 +72,6 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
 
     private handleGetRequest(sendRequest: SendRequestFunction) {
         return (request: Request, response: Response) => {
-            if (!MessageUtilities.has(request.params, 'id')) {
-                response
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const outgoingMessage: ReadVenueMessage = {
                 msg_id: MessageUtilities.generateMessageIdentifier(),
                 msg_intention: 'READ',
@@ -104,16 +94,6 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
 
     private handleDeleteRequest(sendRequest: SendRequestFunction) {
         return async (request: Request, response: Response) => {
-            if (!MessageUtilities.has(request.params, 'id')) {
-                response
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             if (this.resolver && this.handler) {
                 await removeAndReply({
                     assetID: request.params.id,
@@ -225,16 +205,6 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
 
     private handleUpdateRequest(sendRequest: SendRequestFunction) {
         return (request: Request, response: Response) => {
-            if (!MessageUtilities.has(request.params, 'id')) {
-                response
-                    .status(constants.HTTP_STATUS_BAD_REQUEST)
-                    .json(MessageUtilities.wrapInFailure({
-                        message: 'missing parameter id',
-                        code: 'BAD_REQUEST_MISSING_PARAM',
-                    }));
-                return;
-            }
-
             const validate = MessageUtilities.verifyBody(
                 request,
                 response,

--- a/src/attachments/attachments/VenueGatewayInterface.ts
+++ b/src/attachments/attachments/VenueGatewayInterface.ts
@@ -180,12 +180,12 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
                 response,
                 [],
                 {
-                    name: { primitive: 'string' },
-                    capacity: { primitive: 'number' },
                     approximate_capacity: { primitive: 'number' },
                     approximate_fuzziness: { primitive: 'number' },
-                    minimum_capacity: { primitive: 'number' },
+                    capacity: { primitive: 'number' },
                     maximum_capacity: { primitive: 'number' },
+                    minimum_capacity: { primitive: 'number' },
+                    name: { primitive: 'string' },
                 },
             );
 

--- a/src/attachments/attachments/VenueGatewayInterface.ts
+++ b/src/attachments/attachments/VenueGatewayInterface.ts
@@ -18,6 +18,7 @@ import UpdateVenueMessage = VenueMessage.UpdateVenueMessage;
 import ROUTING_KEY = Constants.ROUTING_KEY;
 import GatewayMessageHandler = GatewayMk2.GatewayMessageHandler;
 import * as zod from 'zod';
+import sendZodError = MessageUtilities.sendZodError;
 
 export class VenueGatewayInterface implements GatewayAttachmentInterface {
 
@@ -118,6 +119,7 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(request.body);
 
             if (!validate.success) {
+                sendZodError(response, validate.error);
                 return;
             }
 
@@ -217,6 +219,7 @@ export class VenueGatewayInterface implements GatewayAttachmentInterface {
                 .safeParse(request.body);
 
             if (!validate.success) {
+                sendZodError(response, validate.error);
                 return;
             }
 

--- a/src/utilities/AuthUtilities.ts
+++ b/src/utilities/AuthUtilities.ts
@@ -3,7 +3,8 @@ import { Token } from 'keycloak-connect';
 export namespace AuthUtilities {
 
     export function orProtect(...roles: string[]) {
-        return (token: Token) => {
+        return (token: Token | undefined) => {
+            if (token === undefined) return false;
             if (roles.length === 0) return !token.isExpired();
             // This is left intentionally to short circuit and reduce the function overhead and protect from
             // invalid parameters

--- a/src/utilities/MessageUtilities.ts
+++ b/src/utilities/MessageUtilities.ts
@@ -159,11 +159,13 @@ export namespace MessageUtilities {
         );
     }
 
+    export type CoercingValidator = Record<string, { primitive: 'string' | 'number' | 'boolean' | 'array', validator?: (x: any) => boolean, required?: boolean }>;
+
     export function coerceAndVerifyQuery<P extends string[]>(
         request: Request,
         response: Response,
         required: P,
-        types?: Record<string, { primitive: 'string' | 'number' | 'boolean' | 'array', validator?: (x: any) => boolean, required?: boolean }>,
+        types?: CoercingValidator,
     ) {
         // First step, validate missing keys
         if (!verifyData(request.query, response, required)) return false;
@@ -267,5 +269,10 @@ export namespace MessageUtilities {
 
         return true;
     }
+
+    // Rule of Thumb:
+    //  * Params - coerceAndVerify
+    //  * Query - coerceAndVerify
+    //  * Body - zod
 
 }

--- a/src/utilities/MessageUtilities.ts
+++ b/src/utilities/MessageUtilities.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { constants } from "http2";
-import { ZodError } from "zod";
+import { ZodError, ZodSuberror } from "zod";
 
 export namespace MessageUtilities {
 
@@ -90,6 +90,7 @@ export namespace MessageUtilities {
                 return false;
             }
         } catch (e) {
+            console.error(e);
             response
                 .status(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
                 .json(MessageUtilities.wrapInFailure({
@@ -243,12 +244,42 @@ export namespace MessageUtilities {
         return true;
     }
 
+    function zodErrorToString(error: ZodSuberror) {
+        console.warn(error.message, error.code, error);
+        switch (error.code) {
+        case "custom_error":
+            return `Unknown error at ${error.path.join('.')}: ${error.message}`;
+        case "invalid_union":
+            return `No possible value matched for ${error.path.join('.')}: ${error.unionErrors.map((e) => e.message).join(';  ')}`
+        case "invalid_type":
+            if (error.received === 'undefined') {
+                return `Value missing, ${error.path.join('.')} was required but not provided`;
+            }
+            return `Invalid type, ${error.path.join('.')} was expected to be ${error.expected} but you sent ${error.received}`;
+        case "unrecognized_keys":
+            return `Unrecognised keys at ${error.path.join('.')}, the keys ${error.keys.join(', ')} were not permitted`;
+        case "invalid_enum_value":
+            return `Invalid value provided at ${error.path.join('.')}, the acceptable values are ${error.options.join(', ')}`;
+        case "invalid_date":
+            return `Date at ${error.path.join('.')} was not of a valid format`;
+        case "invalid_string":
+            return `String provided at ${error.path.join('.')} did not match the required format for a ${error.validation}`;
+        case "too_small":
+            return `The provided value at ${error.path.join('.')} was not large enough: must be ${error.inclusive ? '>=' : '>'}${error.minimum}`;
+        case "too_big":
+            return `The provided value at ${error.path.join('.')} was too large: must be ${error.inclusive ? '<=' : '<'}${error.maximum}`;
+        default:
+            return `Error: ${error.message} at ${error.path.join('.')}`;
+        }
+    }
+
     export function sendZodError(res: Response, err: ZodError) {
         res
             .status(constants.HTTP_STATUS_BAD_REQUEST)
             .json(wrapInFailure({
                 code: 'INVALID_REQUEST',
-                message: err.message,
+                message: err.errors.map(zodErrorToString)
+                    .join(';  '),
             }));
     }
 

--- a/src/utilities/MessageUtilities.ts
+++ b/src/utilities/MessageUtilities.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { constants } from "http2";
+import { ZodError } from "zod";
 
 export namespace MessageUtilities {
 
@@ -131,34 +132,6 @@ export namespace MessageUtilities {
         return true;
     }
 
-    export function verifyBody<P extends string[]>(
-        request: Request,
-        response: Response,
-        required: P,
-        types?: Record<string, (x: any) => boolean>,
-    ) {
-        return verifyData(
-            request.body,
-            response,
-            required,
-            types,
-        );
-    }
-
-    export function verifyQuery<P extends string[]>(
-        request: Request,
-        response: Response,
-        required: P,
-        types?: Record<string, (x: any) => boolean>,
-    ) {
-        return verifyData(
-            request.query,
-            response,
-            required,
-            types,
-        );
-    }
-
     export type CoercingValidator = Record<string, { primitive: 'string' | 'number' | 'boolean' | 'array', validator?: (x: any) => boolean, required?: boolean }>;
 
     export function coerceAndVerifyQuery<P extends string[]>(
@@ -268,6 +241,15 @@ export namespace MessageUtilities {
         }
 
         return true;
+    }
+
+    export function sendZodError(res: Response, err: ZodError) {
+        res
+            .status(constants.HTTP_STATUS_BAD_REQUEST)
+            .json(wrapInFailure({
+                code: 'INVALID_REQUEST',
+                message: err.message,
+            }));
     }
 
     // Rule of Thumb:

--- a/tests/attachments/attachments/signup.test.ts
+++ b/tests/attachments/attachments/signup.test.ts
@@ -71,6 +71,7 @@ describe('SignupGatewayInterface.ts', () => {
                 'body',
                 send,
                 { eventID: 'abc' },
+                ['admin']
             );
         });
 

--- a/tests/attachments/attachments/user.test.ts
+++ b/tests/attachments/attachments/user.test.ts
@@ -40,40 +40,12 @@ describe('UserGatewayInterface.ts', () => {
         };
     });
     describe('GET /user', () => {
-        it('rejects on wrong parameter types', async () => {
-            await testParameterTypes(
-                routes['get.user'],
-                GET_USER_INVALID,
-                'query',
-                send,
-            );
-        });
 
         it('sends on a valid message', async () => {
             await testValidRoute(
                 routes['get.user'],
                 GET_USER_VALID,
                 'query',
-                send,
-            );
-        });
-    });
-
-    describe('POST /user', () => {
-        it('rejects on missing parameters', async () => {
-            await testMissingParameters(
-                routes['post.user'],
-                POST_USER_MISSING,
-                'body',
-                send,
-            );
-        });
-
-        it('sends on a valid message', async () => {
-            await testValidRoute(
-                routes['post.user'],
-                POST_USER_VALID,
-                'body',
                 send,
             );
         });

--- a/tests/test-api-data.ts
+++ b/tests/test-api-data.ts
@@ -427,16 +427,12 @@ export const GET_USER_VALID = {
     name: '+tZHXC7NLo73jY0sP7sCgw==',
     username: 'FNc/CrHaxFxwfSB8kfAm2g==',
     email: 'SVkEA29g6WqBFAjO9282SA==',
-    includeEmail: 'true',
-    includeHash: 'true'
 }
 export const GET_USER_INVALID = {
     id: 'VsVU9T1Gppfy/sICOoluuw==',
     name: 'XZ6R+H0AOFLBcpEMWZQ+WQ==',
     username: 'vgaOoQvq/4nsYIAqY9VMAg==',
-    email: 'dV6BV88mzBZG5PX3QfWoNA==',
-    includeEmail: '980',
-    includeHash: 'false'
+    email: 10,
 }
 
 // POST /user post-user

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,6 +39,7 @@ export async function testMissingParameters(
     location: 'query' | 'body',
     send: jest.Mock,
     params?: any,
+    roles?: string[],
 ) {
     const response = new Response();
     const fake = response as unknown as express.Response;
@@ -46,6 +47,7 @@ export async function testMissingParameters(
         location === 'query' ? data : undefined,
         location === 'body' ? data : undefined,
         params,
+        roles,
     );
     await route.handle(req, fake, () => false);
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -29,8 +29,11 @@ export async function testParameterTypes(
         .toHaveBeenCalled();
     expect(response.statusCode)
         .toEqual(constants.HTTP_STATUS_BAD_REQUEST);
-    expect(JSON.stringify(response.body))
-        .toContain('type');
+    console.log(response.body);
+    expect(JSON.stringify(response.body)
+        .includes('type') || JSON.stringify(response.body)
+        .includes('format'))
+        .toBeTruthy();
 }
 
 export async function testMissingParameters(


### PR DESCRIPTION
The delete signup permission route did not have all the permissions required. This adds local only filtering to discovery and delete messages. This is only implemented on signups, however. 